### PR TITLE
Administrateur: Limitation des dossiers liés à certaines démarches

### DIFF
--- a/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
@@ -77,6 +77,9 @@ fr:
     update_start_date: La date de début pour le champ « %{label} » a été modifiée. Le date est désormais %{to}.
     remove_end_date: La date de fin pour le champ « %{label} » a été supprimée.
     update_end_date: La date de fin pour le champ « %{label} » a été modifiée. La date est désormais %{to}.
+    add_procedures_limit: L'option « Limiter à certaines démarches » a été activée pour le champ « %{label} ».
+    remove_procedures_limit: L'option « Limiter à certaines démarches » a été désactivée pour le champ « %{label} ».
+    update_procedures: "Les démarches pour le champ « %{label} » ont été modifiées :"
   private:
     add: L’annotation privée « %{label} » a été ajoutée.
     remove: L’annotation privée « %{label} » a été supprimée.

--- a/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
@@ -211,6 +211,25 @@
         - else
           - list.with_item do
             = t(".#{prefix}.update_max_character_length", label: change.label, to: change.to)
+      - when :procedures_limit
+        - if change.to == "0"
+          - list.with_item do
+            = t(".#{prefix}.remove_procedures_limit", label: change.label)
+        - else 
+          - list.with_item do
+            = t(".#{prefix}.add_procedures_limit", label: change.label)
+      - when :procedures
+        - added = change.to.sort - change.from.sort
+        - removed = change.from.sort - change.to.sort
+        - list.with_item do
+          = t(".#{prefix}.update_procedures", label: change.label)
+          = render Dsfr::ListComponent.new do |list|
+            - if added.present?
+              - list.with_item do
+                = t('.add_option', items: added.map{ |procedure | "« N° #{procedure.id} - #{procedure.libelle} »"}.join(", "))
+            - if removed.present?
+              - list.with_item do
+                = t('.remove_option', items: removed.map{ |procedure | "« N° #{procedure.id} - #{procedure.libelle} »" }.join(", "))
 
   - if @public_move_changes.present?
     - list.with_item do

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -112,6 +112,19 @@
                             date de fin
                           = form.date_field :end_date, class: "fr-input", value: type_de_champ.end_date, id: dom_id(type_de_champ, :end_date)
 
+            - if type_de_champ.dossier_link? && current_administrateur.procedures.count > 1
+              .cell.fr-mt-2w
+                .fr-toggle
+                  = form.check_box :procedures_limit, id: dom_id(type_de_champ, :procedures_limit), class: 'fr-toggle__input'
+                  = form.label :procedures_limit, "Limiter à certaines démarches", for: dom_id(type_de_champ, :procedures_limit), class: 'fr-toggle__label fr-label'
+               
+                - if form.object.procedures_limit?
+                  .fr-badge.fr-badge--info.fr-badge--no-text-transform
+                    Seuls les dossiers déposés par l'usager lui-même seront proposés (ses dossiers "brouillon" et "supprimés" ne lui seront pas proposés)
+
+                  .cell.border-left-dark.fr-mt-1w  
+                    = render TypesDeChampEditor::DossierLinkChampComponent.new(procedures: current_administrateur.procedures, type_de_champ: type_de_champ, form: form, procedure: procedure)
+
         .flex.justify-start.fr-mt-1w.flex-gap
           - if type_de_champ.any_drop_down_list? && !type_de_champ.drop_down_list?
             .flex.column.justify-start.width-33
@@ -196,16 +209,6 @@
 
             = render TypesDeChampEditor::ChampFormattedSimpleComponent.new(type_de_champ:, form:, procedure:)
             = render TypesDeChampEditor::ChampFormattedAdvancedComponent.new(type_de_champ:, form:, procedure:)
-
-          - if type_de_champ.dossier_link? && current_administrateur.procedures.count > 1
-            .flex.column.justify-start.flex-grow
-              .fr-toggle
-                = form.check_box :limiter_procedures, id: dom_id(type_de_champ, :limiter_procedures), class: 'fr-toggle__input'
-                = form.label :limiter_procedures, "Limiter à certaines démarches", for: dom_id(type_de_champ, :limiter_procedures), class: 'fr-toggle__label fr-label'
-
-              - if form.object.limiter_procedures?
-                .cell.fr-mt-1w  
-                  = render TypesDeChampEditor::DossierLinkChampComponent.new(procedures: current_administrateur.procedures, type_de_champ: type_de_champ, form: form, procedure: procedure)
 
     - if type_de_champ.referentiel?
       = render(TypesDeChampEditor::InfoReferentielComponent.new(procedure:, type_de_champ:))

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -197,6 +197,9 @@
             = render TypesDeChampEditor::ChampFormattedSimpleComponent.new(type_de_champ:, form:, procedure:)
             = render TypesDeChampEditor::ChampFormattedAdvancedComponent.new(type_de_champ:, form:, procedure:)
 
+          - if type_de_champ.dossier_link?
+            = render TypesDeChampEditor::DossierLinkChampComponent.new(procedures: current_administrateur.procedures, type_de_champ: type_de_champ, form: form, procedure: procedure)
+
     - if type_de_champ.referentiel?
       = render(TypesDeChampEditor::InfoReferentielComponent.new(procedure:, type_de_champ:))
 
@@ -208,7 +211,7 @@
             = render TypesDeChampEditor::AddChampButtonComponent.new(revision: coordinate.revision, parent: coordinate, is_annotation: coordinate.private?)
 
     = render(Conditions::ChampsConditionsComponent.new(tdc: type_de_champ, upper_tdcs: @upper_coordinates.map(&:type_de_champ), procedure_id: procedure.id))
-
+    
     .flex.justify-between.section.footer
       .position.flex.align-center= (@coordinate.position + 1).to_s
       %button.fr-btn.fr-btn--tertiary-no-outline.fr-icon-arrow-up-line.move-up{ move_button_options(:up) }

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -197,8 +197,15 @@
             = render TypesDeChampEditor::ChampFormattedSimpleComponent.new(type_de_champ:, form:, procedure:)
             = render TypesDeChampEditor::ChampFormattedAdvancedComponent.new(type_de_champ:, form:, procedure:)
 
-          - if type_de_champ.dossier_link?
-            = render TypesDeChampEditor::DossierLinkChampComponent.new(procedures: current_administrateur.procedures, type_de_champ: type_de_champ, form: form, procedure: procedure)
+          - if type_de_champ.dossier_link? && current_administrateur.procedures.count > 1
+            .flex.column.justify-start.flex-grow
+              .fr-toggle
+                = form.check_box :limiter_procedures, id: dom_id(type_de_champ, :limiter_procedures), class: 'fr-toggle__input'
+                = form.label :limiter_procedures, "Limiter à certaines démarches", for: dom_id(type_de_champ, :limiter_procedures), class: 'fr-toggle__label fr-label'
+
+              - if form.object.limiter_procedures?
+                .cell.fr-mt-1w  
+                  = render TypesDeChampEditor::DossierLinkChampComponent.new(procedures: current_administrateur.procedures, type_de_champ: type_de_champ, form: form, procedure: procedure)
 
     - if type_de_champ.referentiel?
       = render(TypesDeChampEditor::InfoReferentielComponent.new(procedure:, type_de_champ:))

--- a/app/components/types_de_champ_editor/dossier_link_champ_component.rb
+++ b/app/components/types_de_champ_editor/dossier_link_champ_component.rb
@@ -9,9 +9,10 @@ class TypesDeChampEditor::DossierLinkChampComponent < TypesDeChampEditor::BaseCh
   def react_props
     {
       id: dom_id(@type_de_champ, :procedures),
-      label: "Démarches concernées",
+      label: "Sélectionnez la ou les démarches concernées",
       items: @procedures.map { |procedure| ["N°#{procedure.id} - #{procedure.libelle}", procedure.id] },
-      name: @form.field_name(:procedures, multiple: true)
+      name: @form.field_name(:procedures, multiple: true),
+      selected_keys: @type_de_champ.procedures.map { |procedure| procedure.id.to_s }
     }
   end
 end

--- a/app/components/types_de_champ_editor/dossier_link_champ_component.rb
+++ b/app/components/types_de_champ_editor/dossier_link_champ_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class TypesDeChampEditor::DossierLinkChampComponent < TypesDeChampEditor::BaseChampComponent
+  def initialize(procedures:, type_de_champ:, form:, procedure:)
+    super(type_de_champ: type_de_champ, form: form, procedure: procedure)
+    @procedures = procedures
+  end
+
+  def react_props
+    {
+      id: dom_id(@type_de_champ, :procedures),
+      label: "Démarches concernées",
+      items: @procedures.map { |procedure| ["N°#{procedure.id} - #{procedure.libelle}", procedure.id] },
+      name: @form.field_name(:procedures, multiple: true)
+    }
+  end
+end

--- a/app/components/types_de_champ_editor/dossier_link_champ_component.rb
+++ b/app/components/types_de_champ_editor/dossier_link_champ_component.rb
@@ -10,9 +10,24 @@ class TypesDeChampEditor::DossierLinkChampComponent < TypesDeChampEditor::BaseCh
     {
       id: dom_id(@type_de_champ, :procedures),
       label: "Sélectionnez la ou les démarches concernées",
-      items: @procedures.map { |procedure| ["N°#{procedure.id} - #{procedure.libelle}", procedure.id] },
+      items:,
       name: @form.field_name(:procedures, multiple: true),
-      selected_keys: @type_de_champ.procedures.map { |procedure| procedure.id.to_s }
+      selected_keys: @type_de_champ.procedures.map { |procedure| procedure.id.to_s },
+      'aria-label': "Liste des démarches",
+      secondary_label: "Démarches concernées",
+      no_items_label: "Aucune démarche sélectionnée"
     }
+  end
+
+  def items
+    items = { '--- Démarches publiées ---' => [], '--- Démarches en test ---' => [], '--- Démarches closes ---' => [] }
+
+    @procedures.each do |procedure|
+      items["--- Démarches publiées ---"] << { label: "N°#{procedure.id} - #{procedure.libelle}", value: procedure.id.to_s } if procedure.aasm_state == "publiee"
+      items["--- Démarches en test ---"] << { label: "N°#{procedure.id} - #{procedure.libelle}", value: procedure.id.to_s } if procedure.aasm_state == "brouillon"
+      items["--- Démarches closes ---"] << { label: "N°#{procedure.id} - #{procedure.libelle}", value: procedure.id.to_s } if procedure.aasm_state == "close"
+    end
+
+    items
   end
 end

--- a/app/components/types_de_champ_editor/dossier_link_champ_component/dossier_link_champ_component.html.haml
+++ b/app/components/types_de_champ_editor/dossier_link_champ_component/dossier_link_champ_component.html.haml
@@ -1,0 +1,2 @@
+%react-fragment.flex-1
+    = render ReactComponent.new "ComboBox/MultiComboBox", **react_props

--- a/app/components/types_de_champ_editor/dossier_link_champ_component/dossier_link_champ_component.html.haml
+++ b/app/components/types_de_champ_editor/dossier_link_champ_component/dossier_link_champ_component.html.haml
@@ -1,2 +1,2 @@
 %react-fragment.flex-1
-    = render ReactComponent.new "ComboBox/MultiComboBox", **react_props
+    = render ReactComponent.new "ComboBox/MultiGroupComboBox", **react_props

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -211,7 +211,7 @@ module Administrateurs
     end
 
     def type_de_champ_update_params
-      params.required(:type_de_champ).permit(:type_champ,
+      permitted_params = params.required(:type_de_champ).permit(:type_champ,
         :libelle,
         :description,
         :mandatory,
@@ -242,6 +242,8 @@ module Administrateurs
         :expression_reguliere_indications,
         :expression_reguliere_exemple_text,
         :expression_reguliere_error_message,
+        :limiter_procedures,
+        procedures: [],
         editable_options: [
           :cadastres,
           :unesco,
@@ -254,6 +256,12 @@ module Administrateurs
           :zones_humides,
           :znieff
         ])
+
+      if permitted_params[:procedures].present?
+        permitted_params[:procedures] = permitted_params[:procedures] != [""] ? permitted_params[:procedures].map { |id| Procedure.find(id) } : []
+      end
+
+      permitted_params
     end
 
     def draft

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -242,7 +242,7 @@ module Administrateurs
         :expression_reguliere_indications,
         :expression_reguliere_exemple_text,
         :expression_reguliere_error_message,
-        :limiter_procedures,
+        :procedures_limit,
         procedures: [],
         editable_options: [
           :cadastres,

--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -10,7 +10,9 @@ import {
   Button,
   TagGroup,
   TagList,
-  Tag
+  Tag,
+  Header,
+  ListBoxSection
 } from 'react-aria-components';
 import { useMemo, useRef, createContext, useContext } from 'react';
 import type { RefObject } from 'react';
@@ -22,6 +24,7 @@ import {
   useMultiList,
   useSingleList,
   useRemoteList,
+  useMultiGroupList,
   useOnFormReset,
   createLoader,
   type ComboBoxProps
@@ -30,6 +33,7 @@ import {
   type Item,
   SingleComboBoxProps,
   MultiComboBoxProps,
+  MultiGroupComboBoxProps,
   RemoteComboBoxProps
 } from './react-aria/props';
 
@@ -245,6 +249,120 @@ export function MultiComboBox(maybeProps: MultiComboBoxProps) {
       >
         {(item) => <ComboBoxItem id={item.value}>{item.label}</ComboBoxItem>}
       </ComboBox>
+      {name ? (
+        <span ref={ref}>
+          {hiddenInputValues.length == 0 ? (
+            <input
+              type="hidden"
+              value=""
+              name={name}
+              form={form}
+              ref={formResetRef}
+            />
+          ) : (
+            hiddenInputValues.map((value, i) => (
+              <input
+                type="hidden"
+                value={value}
+                name={name}
+                form={form}
+                ref={i == 0 ? formResetRef : undefined}
+                key={value}
+              />
+            ))
+          )}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+export function MultiGroupComboBox(maybeProps: MultiGroupComboBoxProps) {
+  const {
+    items: defaultItems,
+    selectedKeys: defaultSelectedKeys,
+    name,
+    form,
+    formValue,
+    className,
+    maxItemsDisplay,
+    maxItemsAlert,
+    focusOnSelect,
+    secondaryLabel,
+    noItemsLabel,
+    ...props
+  } = useMemo(() => s.create(maybeProps, MultiGroupComboBoxProps), [maybeProps]);
+
+  const { ref, dispatch } = useDispatchChangeEvent();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const {
+    selectedItems,
+    hiddenInputValues,
+    onRemove,
+    onReset,
+    items,
+    ...comboBoxProps
+  } = useMultiGroupList({
+    defaultItems,
+    defaultSelectedKeys,
+    formValue,
+    maxItemsDisplay,
+    maxItemsAlert,
+    focusInput: () => {
+      inputRef.current?.focus();
+    },
+    onChange: () => {
+      dispatch();
+      if (focusOnSelect) {
+        document.getElementById(focusOnSelect)?.focus();
+      }
+    }
+  });
+  const formResetRef = useOnFormReset(onReset);
+
+  return (
+    <div className={`fr-ds-combobox__multiple ${className ? className : ''}`}>
+      <ComboBox
+        inputRef={inputRef}
+        menuTrigger="focus"
+        {...comboBoxProps}
+        {...props}
+      >
+        {Object.keys(items).map((key) => (
+          <ListBoxSection key={key}>
+            <Header>{key}</Header>
+            {items[key].map((item) => (
+              <ComboBoxItem id={item.value} key={item.value}>
+                      {item.label}
+              </ComboBoxItem>
+            ))}
+            </ListBoxSection>
+        ))}
+      </ComboBox>
+      {secondaryLabel ? (
+        <Label className="fr-label">{secondaryLabel}</Label>
+      ) : null
+      }
+      {selectedItems.length > 0 ? (
+        <TagGroup onRemove={onRemove} aria-label={props['aria-label']}>
+          <TagList items={selectedItems} className="fr-tag-list">
+            {selectedItems.map((item) => (
+              <Tag
+                key={item.value}
+                id={item.value}
+                textValue={`Retirer ${item.label}`}
+                className="fr-tag fr-tag--sm fr-tag--dismiss"
+              >
+                {item.label}
+                <Button slot="remove" className="fr-tag--dismiss"></Button>
+              </Tag>
+            ))}
+          </TagList>
+        </TagGroup>
+      ) : noItemsLabel ? (
+          <p><i>{noItemsLabel}</i></p>
+        ) : null}
       {name ? (
         <span ref={ref}>
           {hiddenInputValues.length == 0 ? (

--- a/app/javascript/components/react-aria/hooks.ts
+++ b/app/javascript/components/react-aria/hooks.ts
@@ -378,6 +378,174 @@ export function useMultiList({
   };
 }
 
+export function useMultiGroupList({
+  defaultItems,
+  defaultSelectedKeys,
+  onChange,
+  focusInput,
+  formValue,
+  maxItemsDisplay = DEFAULT_MAX_ITEMS_DISPLAY,
+  maxItemsAlert
+}: {
+  defaultItems?: Record<string, Item[]>;
+  defaultSelectedKeys?: string[];
+  allowsCustomValue?: boolean;
+  valueSeparator?: string | false;
+  onChange?: () => void;
+  focusInput?: () => void;
+  formValue?: 'text' | 'key';
+  maxItemsDisplay?: number;
+  maxItemsAlert?: string;
+}) {
+  const [selectedKeys, setSelectedKeys] = useState(
+    () => new Set(defaultSelectedKeys ?? [])
+  );
+  const [inputValue, setInputValue] = useState('');
+  let defaultItemsArray: Item[] = [];
+
+  for (const key in defaultItems) {
+    defaultItemsArray = defaultItemsArray.concat(defaultItems[key]);
+  }
+
+  const items = useMemo(
+    () => (defaultItemsArray ? distinctBy(defaultItemsArray, 'value') : []),
+    [defaultItemsArray]
+  );
+  const itemsIndex = useMemo(() => {
+    const index = new Map<string, Item>();
+    for (const item of items) {
+      index.set(item.value, item);
+    }
+    return index;
+  }, [items]);
+  const filteredItems = useMemo(
+    () =>
+      inputValue.length == 0
+        ? items.filter((item) => !selectedKeys.has(item.value))
+        : matchSorter(
+            items.filter((item) => !selectedKeys.has(item.value)),
+            inputValue,
+            { keys: ['label'] }
+          ),
+    [items, inputValue, selectedKeys]
+  );
+  const selectedItems = useMemo(() => {
+    const selectedItems: Item[] = [];
+    for (const key of selectedKeys) {
+      const item = itemsIndex.get(key);
+      if (item) {
+        selectedItems.push(item);
+      }
+    }
+    return selectedItems;
+  }, [itemsIndex, selectedKeys]);
+  const hiddenInputValues = useMemo(() => {
+    const values = selectedItems.map((item) =>
+      formValue == 'text' ? item.label : item.value
+    );
+    if (inputValue == '') {
+      return values;
+    }
+    return [
+      ...new Set([
+        ...values
+      ])
+    ];
+  }, [
+    selectedItems,
+    inputValue,
+    formValue
+  ]);
+  const isSelectionSetRef = useRef(false);
+  const initialSelectedKeysRef = useRef(defaultSelectedKeys);
+
+  // reset default selected keys when props change
+  useEffect(() => {
+    if (!isEqual(initialSelectedKeysRef.current, defaultSelectedKeys)) {
+      initialSelectedKeysRef.current = defaultSelectedKeys;
+      setSelectedKeys(new Set(defaultSelectedKeys));
+    }
+  }, [defaultSelectedKeys]);
+
+  const onSelectionChange = useEvent<
+    NonNullable<ComboBoxProps['onSelectionChange']>
+  >((key) => {
+    if (key) {
+      isSelectionSetRef.current = true;
+      setSelectedKeys((keys) => {
+        const selectedKeys = new Set(keys.values());
+        selectedKeys.add(String(key));
+        return selectedKeys;
+      });
+      setInputValue('');
+      onChange?.();
+    }
+  });
+
+  const onInputChange = useEvent<NonNullable<ComboBoxProps['onInputChange']>>(
+    (value) => {
+      const isSelectionSet = isSelectionSetRef.current;
+      isSelectionSetRef.current = false;
+      if (isSelectionSet) {
+        setInputValue('');
+        return;
+      }
+      
+      setInputValue(value);
+    }
+  );
+
+  const onRemove = useEvent<NonNullable<TagGroupProps['onRemove']>>(
+    (removedKeys) => {
+      setSelectedKeys((keys) => {
+        const selectedKeys = new Set(keys.values());
+        for (const key of removedKeys) {
+          selectedKeys.delete(String(key));
+        }
+        // focus input when all items are removed
+        if (selectedKeys.size == 0) {
+          focusInput?.();
+        }
+        return selectedKeys;
+      });
+      onChange?.();
+    }
+  );
+
+  const onReset = useEvent(() => {
+    setSelectedKeys(new Set());
+    setInputValue('');
+  });
+
+  const displayedItems = filteredItems.slice(0, maxItemsDisplay);
+
+  const displayedItemsMap : Record<string, Item[]> = {};
+  for (const key in defaultItems){
+    displayedItemsMap[key] = defaultItems[key].filter((item) => {
+      return displayedItems.includes(item);
+    });
+
+  }
+
+  if (maxItemsAlert && filteredItems.length > maxItemsDisplay) {
+    displayedItemsMap[Object.keys(displayedItemsMap)[Object.keys(displayedItemsMap).length - 1]].push({
+      label: maxItemsAlert,
+      value: 'combo-alert-message'
+    });
+  }
+
+  return {
+    onRemove,
+    onSelectionChange,
+    onInputChange,
+    selectedItems,
+    items: displayedItemsMap,
+    hiddenInputValues,
+    inputValue,
+    onReset
+  };
+}
+
 export function useRemoteList({
   load,
   defaultItems,

--- a/app/javascript/components/react-aria/props.ts
+++ b/app/javascript/components/react-aria/props.ts
@@ -64,6 +64,20 @@ export const MultiComboBoxProps = s.assign(
     })
   )
 );
+export const MultiGroupComboBoxProps = s.assign(
+  ComboBoxPropsSchema,
+  s.partial(
+    s.object({
+      selectedKeys: s.array(s.string()),
+      maxItemsDisplay: s.number(),
+      maxItemsAlert: s.string(),
+      focusOnSelect: s.string(),
+      items: s.record(s.string(), s.array(Item)),
+      secondaryLabel: s.string(),
+      noItemsLabel: s.string()
+    })
+  )
+);
 export const RemoteComboBoxProps = s.assign(
   ComboBoxPropsSchema,
   s.partial(
@@ -80,6 +94,7 @@ export type SingleComboBoxProps = s.Infer<typeof SingleComboBoxProps> & {
   children?: ReactNode;
 };
 export type MultiComboBoxProps = s.Infer<typeof MultiComboBoxProps>;
+export type MultiGroupComboBoxProps = s.Infer<typeof MultiGroupComboBoxProps>;
 export type RemoteComboBoxProps = s.Infer<typeof RemoteComboBoxProps> & {
   children?: ReactNode;
   loader: Loader | string;

--- a/app/javascript/controllers/type_de_champ_editor_controller.ts
+++ b/app/javascript/controllers/type_de_champ_editor_controller.ts
@@ -59,7 +59,8 @@ export class TypeDeChampEditorController extends ApplicationController {
           this.requestSubmitForm(target.form);
         }
       },
-      changeable: (target) => this.save(target.form)
+      changeable: (target) => this.save(target.form),
+      hidden: (target) => this.save(target.form)
     });
   }
 

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -537,6 +537,19 @@ class ProcedureRevision < ApplicationRecord
           from_type_de_champ.max_character_length,
           to_type_de_champ.max_character_length)
       end
+    elsif to_type_de_champ.dossier_link?
+      if from_type_de_champ.procedures_limit != to_type_de_champ.procedures_limit
+        changes << ProcedureRevisionChange::UpdateChamp.new(from_type_de_champ,
+          :procedures_limit,
+          from_type_de_champ.procedures_limit,
+          to_type_de_champ.procedures_limit)
+      end
+      if from_type_de_champ.procedures != to_type_de_champ.procedures
+        changes << ProcedureRevisionChange::UpdateChamp.new(from_type_de_champ,
+          :procedures,
+          from_type_de_champ.procedures,
+          to_type_de_champ.procedures)
+      end
     end
     changes
   end

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -163,6 +163,8 @@ class TypeDeChamp < ApplicationRecord
 
   belongs_to :referentiel, optional: true, inverse_of: :types_de_champ
 
+  has_and_belongs_to_many :procedures
+
   delegate :estimated_fill_duration, :estimated_read_duration, :tags_for_template, :libelles_for_export, :libelle_for_export, :primary_options, :secondary_options, :columns, to: :dynamic_type
 
   class WithIndifferentAccess

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -156,7 +156,7 @@ class TypeDeChamp < ApplicationRecord
                  :collapsible_explanation_text,
                  :header_section_level,
                  :referentiel_mapping,
-                 :limiter_procedures
+                 :procedures_limit
 
   has_many :revision_types_de_champ, -> { revision_ordered }, class_name: 'ProcedureRevisionTypeDeChamp', dependent: :destroy, inverse_of: :type_de_champ
 
@@ -164,6 +164,7 @@ class TypeDeChamp < ApplicationRecord
 
   belongs_to :referentiel, optional: true, inverse_of: :types_de_champ
 
+  # procédures pour le type de champ dossier_link
   has_and_belongs_to_many :procedures
 
   delegate :estimated_fill_duration, :estimated_read_duration, :tags_for_template, :libelles_for_export, :libelle_for_export, :primary_options, :secondary_options, :columns, to: :dynamic_type
@@ -325,8 +326,8 @@ class TypeDeChamp < ApplicationRecord
     collapsible_explanation_enabled == "1"
   end
 
-  def limiter_procedures?
-    limiter_procedures == "1"
+  def procedures_limit?
+    procedures_limit == "1"
   end
 
   def prefillable?
@@ -673,7 +674,8 @@ class TypeDeChamp < ApplicationRecord
       :formatted_mode, :numbers_accepted, :letters_accepted, :special_characters_accepted,
       :min_character_length, :max_character_length,
       :expression_reguliere, :expression_reguliere_indications, :expression_reguliere_exemple_text, :expression_reguliere_error_message
-    ]
+    ],
+    type_champs.fetch(:dossier_link) => [:procedures_limit]
   }
 
   def clean_options

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -155,7 +155,8 @@ class TypeDeChamp < ApplicationRecord
                  :collapsible_explanation_enabled,
                  :collapsible_explanation_text,
                  :header_section_level,
-                 :referentiel_mapping
+                 :referentiel_mapping,
+                 :limiter_procedures
 
   has_many :revision_types_de_champ, -> { revision_ordered }, class_name: 'ProcedureRevisionTypeDeChamp', dependent: :destroy, inverse_of: :type_de_champ
 
@@ -322,6 +323,10 @@ class TypeDeChamp < ApplicationRecord
 
   def collapsible_explanation_enabled?
     collapsible_explanation_enabled == "1"
+  end
+
+  def limiter_procedures?
+    limiter_procedures == "1"
   end
 
   def prefillable?

--- a/db/migrate/20250526154734_create_types_de_champ_procedures_join_table.rb
+++ b/db/migrate/20250526154734_create_types_de_champ_procedures_join_table.rb
@@ -1,0 +1,5 @@
+class CreateTypesDeChampProceduresJoinTable < ActiveRecord::Migration[7.1]
+  def change
+    create_join_table :types_de_champ, :procedures
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,6 +17,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_26_154734) do
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "postgis"
+  disable_extension "postgis_tiger_geocoder"
   enable_extension "sslinfo"
   enable_extension "unaccent"
 
@@ -269,7 +270,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_26_154734) do
     t.string "value"
     t.jsonb "value_json"
     t.index ["dossier_id", "stream", "stable_id", "row_id"], name: "index_champs_on_dossier_id_and_stream_and_stable_id_and_row_id", unique: true
-    t.index ["dossier_id", "stream", "stable_id", "row_id"], name: "index_champs_on_stream_and_public_id", unique: true
+    t.index ["dossier_id", "stream", "stable_id", "row_id"], name: "index_champs_on_stream_and_public_id", unique: true, nulls_not_distinct: true
     t.index ["dossier_id"], name: "index_champs_on_dossier_id"
     t.index ["etablissement_id"], name: "index_champs_on_etablissement_id"
     t.index ["row_id"], name: "index_champs_on_row_id"
@@ -932,10 +933,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_26_154734) do
     t.integer "assign_to_id"
     t.datetime "created_at", precision: nil
     t.jsonb "displayed_columns", default: [], null: false, array: true
-    t.jsonb "displayed_fields", default: [{"label" => "Demandeur", "table" => "user", "column" => "email"}], null: false
+    t.jsonb "displayed_fields", default: [{"label"=>"Demandeur", "table"=>"user", "column"=>"email"}], null: false
     t.jsonb "expirant_filters", default: [], null: false, array: true
-    t.jsonb "filters", default: {"tous" => [], "suivis" => [], "traites" => [], "a-suivre" => [], "archives" => [], "expirant" => [], "supprimes" => []}, null: false
-    t.jsonb "sort", default: {"order" => "desc", "table" => "notifications", "column" => "notifications"}, null: false
+    t.jsonb "filters", default: {"tous"=>[], "suivis"=>[], "traites"=>[], "a-suivre"=>[], "archives"=>[], "expirant"=>[], "supprimes"=>[]}, null: false
+    t.jsonb "sort", default: {"order"=>"desc", "table"=>"notifications", "column"=>"notifications"}, null: false
     t.jsonb "sorted_column"
     t.jsonb "suivis_filters", default: [], null: false, array: true
     t.jsonb "supprimes_filters", default: [], null: false, array: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_20_110339) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_26_154734) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "postgis"
-  disable_extension "postgis_tiger_geocoder"
   enable_extension "sslinfo"
   enable_extension "unaccent"
 
@@ -270,7 +269,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_20_110339) do
     t.string "value"
     t.jsonb "value_json"
     t.index ["dossier_id", "stream", "stable_id", "row_id"], name: "index_champs_on_dossier_id_and_stream_and_stable_id_and_row_id", unique: true
-    t.index ["dossier_id", "stream", "stable_id", "row_id"], name: "index_champs_on_stream_and_public_id", unique: true, nulls_not_distinct: true
+    t.index ["dossier_id", "stream", "stable_id", "row_id"], name: "index_champs_on_stream_and_public_id", unique: true
     t.index ["dossier_id"], name: "index_champs_on_dossier_id"
     t.index ["etablissement_id"], name: "index_champs_on_etablissement_id"
     t.index ["row_id"], name: "index_champs_on_row_id"
@@ -933,10 +932,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_20_110339) do
     t.integer "assign_to_id"
     t.datetime "created_at", precision: nil
     t.jsonb "displayed_columns", default: [], null: false, array: true
-    t.jsonb "displayed_fields", default: [{"label"=>"Demandeur", "table"=>"user", "column"=>"email"}], null: false
+    t.jsonb "displayed_fields", default: [{"label" => "Demandeur", "table" => "user", "column" => "email"}], null: false
     t.jsonb "expirant_filters", default: [], null: false, array: true
-    t.jsonb "filters", default: {"tous"=>[], "suivis"=>[], "traites"=>[], "a-suivre"=>[], "archives"=>[], "expirant"=>[], "supprimes"=>[]}, null: false
-    t.jsonb "sort", default: {"order"=>"desc", "table"=>"notifications", "column"=>"notifications"}, null: false
+    t.jsonb "filters", default: {"tous" => [], "suivis" => [], "traites" => [], "a-suivre" => [], "archives" => [], "expirant" => [], "supprimes" => []}, null: false
+    t.jsonb "sort", default: {"order" => "desc", "table" => "notifications", "column" => "notifications"}, null: false
     t.jsonb "sorted_column"
     t.jsonb "suivis_filters", default: [], null: false, array: true
     t.jsonb "supprimes_filters", default: [], null: false, array: true
@@ -1073,6 +1072,11 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_20_110339) do
     t.index ["service_id"], name: "index_procedures_on_service_id"
     t.index ["tags"], name: "index_procedures_on_tags", using: :gin
     t.index ["zone_id"], name: "index_procedures_on_zone_id"
+  end
+
+  create_table "procedures_types_de_champ", id: false, force: :cascade do |t|
+    t.bigint "procedure_id", null: false
+    t.bigint "type_de_champ_id", null: false
   end
 
   create_table "procedures_zones", id: false, force: :cascade do |t|

--- a/spec/components/types_de_champ_editor/dossier_link_champ_component_spec.rb
+++ b/spec/components/types_de_champ_editor/dossier_link_champ_component_spec.rb
@@ -1,0 +1,68 @@
+describe TypesDeChampEditor::DossierLinkChampComponent, type: :component do
+  describe 'render' do
+    let(:procedures) do
+      [
+        create(:procedure, id: 1, libelle: "Procedure 1", aasm_state: "publiee"),
+        create(:procedure, id: 2, libelle: "Procedure 2", aasm_state: "brouillon"),
+        create(:procedure, id: 3, libelle: "Procedure 3", aasm_state: "close")
+      ]
+    end
+    let(:procedure) { create(:procedure) }
+    let(:type_de_champ) { build(:type_de_champ_dossier_link) }
+    let(:form) { instance_double('Form') }
+    subject { described_class.new(procedures: procedures, type_de_champ: type_de_champ, form: form, procedure: procedure) }
+
+    before do
+      allow(form).to receive(:field_name).and_return("")
+    end
+
+    describe '#react_props' do
+      it 'returns the correct props' do
+        expected_props = {
+          id: "procedures_type_de_champ",
+          label: "Sélectionnez la ou les démarches concernées",
+          items: {
+            '--- Démarches publiées ---' => [{ label: "N°1 - Procedure 1", value: "1" }],
+            '--- Démarches en test ---' => [{ label: "N°2 - Procedure 2", value: "2" }],
+            '--- Démarches closes ---' => [{ label: "N°3 - Procedure 3", value: "3" }]
+          },
+          name: "",
+          selected_keys: [],
+          'aria-label': "Liste des démarches",
+          secondary_label: "Démarches concernées",
+          no_items_label: "Aucune démarche sélectionnée"
+        }
+
+        expect(subject.react_props).to eq(expected_props)
+      end
+    end
+
+    describe '#items' do
+      it 'returns the correct items' do
+        expected_items = {
+          '--- Démarches publiées ---' => [{ label: "N°1 - Procedure 1", value: "1" }],
+          '--- Démarches en test ---' => [{ label: "N°2 - Procedure 2", value: "2" }],
+          '--- Démarches closes ---' => [{ label: "N°3 - Procedure 3", value: "3" }]
+        }
+
+        expect(subject.items).to eq(expected_items)
+      end
+    end
+
+    context 'with a procedure having no selected keys' do
+      let(:type_de_champ) { build(:type_de_champ, procedures: []) }
+
+      it 'returns an empty selected_keys' do
+        expect(subject.react_props[:selected_keys]).to eq([])
+      end
+    end
+
+    context 'with a procedure having multiple selected keys' do
+      let(:type_de_champ) { build(:type_de_champ, procedures: procedures) }
+
+      it 'returns the correct selected_keys' do
+        expect(subject.react_props[:selected_keys]).to eq(["1", "2", "3"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Contexte
Développement des features proposées via l'issue suivante : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/11538

# Résumé
ETQ Administrateur, je veux limiter les dossiers liés à certaines démarches et aux dossiers de l'usager

## Résumé fonctionnel
- Ajout d'une checkbox qui indique si l'administrateur souhaite limiter le lien vers un autre dossier à certaines démarches
- Ajout d'un composant ComboBox pour la sélection des démarches auxquelles l'administrateur veut limiter les dossiers

## Résumé technique
- `app/components/procedure/revision_changes_component/revision_changes_component.fr.yml` : ajout de texte pour les révisions
- `app/components/procedure/revision_changes_component/revision_changes_component.html.haml` : ajout du cas où on modifie la checkbox ou la liste des démarches pour les révisions
- `app/components/types_de_champ_editor/champ_component/champ_component.html.haml` : ajout dans la vue du composant pour le lien vers un autre dossier
- `app/components/types_de_champ_editor/dossier_link_champ_component.rb` et `app/components/types_de_champ_editor/dossier_link_champ_component/dossier_link_champ_component.html.haml` : ajout d'un composant Rails pour le lien vers un autre dossier
- `app/controllers/administrateurs/types_de_champ_controller.rb` : changement des paramètres permis (ajout de procedures_limit et procedures) pour le controller pour la mise à jour du type de champ
- `app/javascript/components/ComboBox.tsx`, `app/javascript/components/react-aria/hooks.ts` et `app/javascript/components/react-aria/props.ts`  : ajout d'un nouveau composant MultiGroupComboBox inspiré du MultiComboBox pour pouvoir l'utiliser avec un hash dont les clés sont les headers et les valeurs les liste d'items
- `app/javascript/controllers/type_de_champ_editor_controller.ts`: changement pour que la sauvegarde automatique s'applique lorsqu'on manipule une ComboBox
- `app/models/procedure_revision.rb` : mise en place révision quand on modifie la checkbox ou la combobox pour le lien vers un autre dossier
- `app/models/type_de_champ.rb` : ajout attribut procedures_limit qui représente la checkbox et procedures pour la liste des démarches limitées
- `db/migrate/20250526154734_create_types_de_champ_procedures_join_table.rb` et `db/schema.rb` : migration pour créer une table d'association entre type de champs et procédure
- `spec/components/types_de_champ_editor/dossier_link_champ_component_spec.rb` : test unitaire

## Tests unitaires
- `spec/components/types_de_champ_editor/dossier_link_champ_component_spec.rb`

## Tests fonctionnels
En tant qu’administrateur,
- créer une démarche
- créer une autre démarche avec un champ Lien vers un autre dossier
- cliquer sur la checkbox/le toggle "Limiter à certaines démarches" et sélectionner les démarches à limiter