### PR TITLE
5266 lien dossier invite

### DIFF
--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.en.yml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.en.yml
@@ -1,3 +1,4 @@
 ---
 en:
   not_found: This file is unknown
+  not_initiator: This field can only be completed by the file initiator

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.fr.yml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.fr.yml
@@ -1,3 +1,4 @@
 ---
 fr:
   not_found: Ce dossier est inconnu
+  not_initiator: Ce champ ne peut-être complété que par l'initiateur du dossier

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
@@ -5,7 +5,7 @@
       .fr-info-text.fr-mb-4w
         - lien = link_to( " N° #{@champ.selected} ",dossier_url(@champ.selected), target: '_blank', rel: 'noopener' )
         = sanitize(dossier.text_summary(lien),tags: %w(a), attributes: %w(href target rel))
-- else 
+- elsif @champ.type_de_champ&.options&.dig("procedures_limit")&.to_i == 1 && @champ.dossier.user == current_user
   - if render_as_radios?
     .fr-fieldset__content
       - dossier_options_for(@champ).each do |item|
@@ -51,7 +51,9 @@
       .fr-info-text.fr-mb-4w 
         - lien = link_to( " N° #{@champ.selected} ",dossier_url(@champ.selected), target: '_blank', rel: 'noopener' )
         = sanitize(dossier.text_summary(lien),tags: %w(a), attributes: %w(href target rel))
-
-
+- else
+  .fr-fieldset__content.fr-mt-2w
+    %p{style: 'color: #0063CB;'}
+      = t('.not_initiator', scope: i18n_scope)
 
 


### PR DESCRIPTION
# Contexte

Développement des features proposées via l'issue suivante : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/11539

# Résumé

ETQ invité,
Je modifie un dossier initié par un usager,
SI le dossier contient un champ lien vers un dossier avec option "association de démarche",
Alors le champ est désactivé, et je ne peux pas le compléter/modifier (si le champ a déjà une valeur).

## Résumé Fonctionnel
- Modification du champ lien dossier en usager
- 5 options ou moins : bouton radio 
- +5 et moins de 20 numéros de dossier
- 20 ou plus dossiers SimpleComboBox

## Tests unitaires

- spec/components/editable_champ/dossier_link_component/dossier_link_component_spec.rb

## Tests fonctionnels

En tant qu'administrateur : 
- créer une démarche sans instructeur. (1)
- créer une démarche avec un instructeur. (2)
- créer une démarche avec au moins deux liens vers un dossier. (3)

En tant qu'usager : 
- déposer un dossier pour chacune des démarche. Pour les champs lien vers un dossier, renseigner le dossier (1) et le dossier (2).
- invité un usager a compléter le dossier il ne doit pas avoir la possibilité de renseigné les champ association de démarche.

En tant qu'instructeur : 
- consulter le dossier de la démarche (3)
- essayer de consulter les deux liens. Un des liens doit fonctionner et l'autre doit afficher une modale. comme dans la maquette :  https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/11540

