### PR TITLE
Correctifs UI UX instructeur

### DIFF
--- a/app/assets/stylesheets/gallery.scss
+++ b/app/assets/stylesheets/gallery.scss
@@ -1,8 +1,4 @@
 .gallery {
-  a {
-    background-image: none;
-  }
-
   .champ-libelle {
     margin-top: 0.5rem;
   }

--- a/app/components/dossiers/no_access_to_dossier_component/no_access_to_dossier_component.html.haml
+++ b/app/components/dossiers/no_access_to_dossier_component/no_access_to_dossier_component.html.haml
@@ -1,12 +1,12 @@
 = render Dsfr::ModalComponent.new("no-access-to-dossier", t(".modal.title"), "#{t(".link.title")} #{dossier.id}", trigger_using_link: true) do |modal|
   - modal.with_body do
-    = render Dsfr::AlertComponent.new(state: :warning, heading_level: 'p') do |c|
+    = render Dsfr::AlertComponent.new(state: :warning, heading_level: 'p', size: :sm) do |c|
       - c.with_body do
-        %p.fr-text<
+        %p.fr-text{:style => "font-weight: normal;"}<
           = t(".modal.content.consulter")
           %b<
-            = t(".modal.content.contacter") 
-          = "#{t(".modal.content.de_la_demarche")} \"#{procedure_name}\" #{t(".modal.content.demander")}" 
+            = t(".modal.content.contacter")
+          = "#{t(".modal.content.de_la_demarche")} \"#{procedure_name}\" #{t(".modal.content.demander")}"
           %b<
             = "#{t(".modal.content.ajouter")} :"
           %ul


### PR DESCRIPTION
> [!IMPORTANT]
> Ne pas merger pour l'instant, voir avec l'équipe comment on s'organise pour les branches de correction UI UX 

# Contenu fonctionnel

L'UI côté instructeur pour le lien vers un dossier a été amélioré.

# Validation

## Technique

- `app/assets/stylesheets/gallery.scss` : supprime la partie concernant les liens car cela empêchait d'afficher le lien en souligné
- `app/components/dossiers/no_access_to_dossier_component/no_access_to_dossier_component.html.haml`: ajout d'un paramètre size pour l'alerte pour ne pas afficher le titre "Attention". Ajout d'un attribut style pour éviter que tout le texte soit en gras

## Fonctionnel

- ETQ administrateur, créer deux démarches : une avec des champs quelconques (Démarche 1) et une avec un champ Lien vers un dossier (Démarche 2) (sélectionner Démarche 1 et Démarche 2 dans l'option Limiter à certaines démarches).
- ETQ usager, déposer un dossier (n°1) sur Démarche 1.
- ETQ usager, déposer un dossier (n°2) sur Démarche 2.
- ETQ instructeur, aller sur le dossier déposé (n°2) sur la Démarche 2.
- [ ] Le dossier a le format lien (souligné)
- [ ] L'intitulé de la démarche et le nom du service sont mis entre guillemets
- ETQ administrateur, retirer test@exemple.fr des instructeurs de la Démarche 1
- ETQ instructeur, aller sur la page concernant le dossier déposé sur la Démarche 2 (n°2)
- ETQ instructeur, cliquer sur le dossier (n°1) sur le champ Lien vers un dossier. La modale s'affiche. 
- [ ] L'alerte n'a plus le titre "Attention :".
- [ ] Seuls certains passages du texte sont en gras.
- [ ] L'email a le format lien (souligné)
 