### PR TITLE
Correctifs UI UX administrateur

### DIFF
--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -142,12 +142,18 @@
                 .fr-toggle
                   = form.check_box :procedures_limit, id: dom_id(type_de_champ, :procedures_limit), class: 'fr-toggle__input'
                   = form.label :procedures_limit, "Limiter à certaines démarches", for: dom_id(type_de_champ, :procedures_limit), class: 'fr-toggle__label fr-label'
-               
-                - if form.object.procedures_limit?
-                  .fr-badge.fr-badge--info.fr-badge--no-text-transform
-                    Seuls les dossiers déposés par l'usager lui-même seront proposés (ses dossiers "brouillon" et "supprimés" ne lui seront pas proposés)
 
-                  .cell.border-left-dark.fr-mt-1w  
+                - if form.object.procedures_limit?
+                  .border-left-dark.fr-mt-1w
+                    .fr-notice.fr-notice--info.fr-my-2w
+                      .fr-container
+                        %p
+                          %span.fr-notice__title
+                          %span.fr-notice__body
+                            Seuls les dossiers
+                            %strong déposés par l'usager lui-même
+                            seront proposés (ses dossiers "brouillon" et "supprimés" ne lui seront pas proposés)
+
                     = render TypesDeChampEditor::DossierLinkChampComponent.new(procedures: current_administrateur.procedures, type_de_champ: type_de_champ, form: form, procedure: procedure)
 
         .flex.justify-start.fr-mt-1w.flex-gap
@@ -232,7 +238,7 @@
             = render TypesDeChampEditor::AddChampButtonComponent.new(revision: coordinate.revision, parent: coordinate, is_annotation: coordinate.private?)
 
     = render(Conditions::ChampsConditionsComponent.new(tdc: type_de_champ, upper_tdcs: @upper_coordinates.map(&:type_de_champ), procedure_id: procedure.id))
-    
+
     .flex.justify-between.section.footer
       .position.flex.align-center= (@coordinate.position + 1).to_s
       %button.fr-btn.fr-btn--tertiary-no-outline.fr-icon-arrow-up-line.move-up{ move_button_options(:up) }

--- a/app/components/types_de_champ_editor/dossier_link_champ_component.rb
+++ b/app/components/types_de_champ_editor/dossier_link_champ_component.rb
@@ -14,8 +14,9 @@ class TypesDeChampEditor::DossierLinkChampComponent < TypesDeChampEditor::BaseCh
       name: @form.field_name(:procedures, multiple: true),
       selected_keys: @type_de_champ.procedures.map { |procedure| procedure.id.to_s },
       'aria-label': "Liste des démarches",
-      secondary_label: "Démarches concernées",
-      no_items_label: "Aucune démarche sélectionnée"
+      secondary_label: "Démarche(s) concernée(s)",
+      no_items_label: "Aucune démarche sélectionnée",
+      has_label_class_fr_label: false
     }
   end
 

--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -47,11 +47,13 @@ export function ComboBox({
   isLoading,
   isOpen,
   placeholder,
+  hasLabelClassFrLabel = true,
   ...props
 }: ComboBoxProps & {
   inputRef?: RefObject<HTMLInputElement | null>;
   isOpen?: boolean;
   placeholder?: string;
+  hasLabelClassFrLabel?: boolean;
 }) {
   return (
     <AriaComboBox
@@ -60,7 +62,7 @@ export function ComboBox({
       shouldFocusWrap={true}
     >
       {label ? (
-        <Label className="fr-label">
+        <Label className={hasLabelClassFrLabel ? 'fr-label' : ''}>
           {label}
           {description ? (
             <Text slot="description" className="fr-hint-text fr-mb-1w">
@@ -332,7 +334,7 @@ export function MultiGroupComboBox(maybeProps: MultiGroupComboBoxProps) {
         ))}
       </ComboBox>
       {secondaryLabel ? (
-        <Label className="fr-label">{secondaryLabel}</Label>
+        <Label className="fr-mt-2w">{secondaryLabel}</Label>
       ) : null
       }
       {selectedItems.length > 0 ? (

--- a/app/javascript/components/react-aria/props.ts
+++ b/app/javascript/components/react-aria/props.ts
@@ -36,7 +36,8 @@ const ComboBoxPropsSchema = s.partial(
     items: s.union([s.array(Item), ArrayOfStrings, ArrayOfTuples]),
     formValue: s.enums(['text', 'key']),
     form: s.string(),
-    data: s.record(s.string(), s.string())
+    data: s.record(s.string(), s.string()),
+    hasLabelClassFrLabel: s.boolean()
   })
 );
 export const SingleComboBoxProps = s.assign(


### PR DESCRIPTION
> [!IMPORTANT]
> Ne pas merger pour l'instant, voir avec l'équipe comment on s'organise pour les branches de correction UI UX 

# Contenu fonctionnel

Quelques correctifs concernant l'UI ont été mise en place.

# Validation

## Technique

- `app/components/types_de_champ_editor/champ_component/champ_component.html.haml` : changement de composant pour correspondre à la maquette (bandeau d'information importante)
- `app/components/types_de_champ_editor/dossier_link_champ_component.rb`, `app/javascript/components/ComboBox.tsx`, `app/javascript/components/react-aria/props.ts` : ajout d'un prop pour le composant react pour optionnellement mettre une classe fr-label sur le label de la combobox

## Fonctionnel

- ETQ administrateur, créer une démarche avec des champs quelconques (Démarche 1)
- ETQ administrateur, créer une démarche avec un champ Lien vers un dossier (Démarche 2)
- ETQ administrateur, activer l'option "Limiter à certaines démarches"
- [ ] Les éléments sont espacés verticalement
- [ ] Le bandeau bleu d'information utilise le composant [bandeau d'information importante](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/bandeau-d-information-importante) et seule la partie "déposés par l’usager lui-même" est mise en gras.
- [ ] Les libellés "Sélectionnez la ou les démarches concernées" et "Démarche(s) concernée(s)" sont mis en gras et petites majuscules comme Libellé du champ et Description du champ (optionnel)
- [ ] Le titre Démarche(s) concernée(s) a les s entre parenthèses
- [ ] Le trait liant l’ensemble des éléments inclut également le bandeau bleu d’info.
 