### PR TITLE
Correctifs UI UX usager

### DIFF
--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
@@ -3,40 +3,50 @@
     = @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, inputmode: :numeric, min: 1, pattern: "[0-9]{1,12}", autocomplete: 'off', required: @champ.required?, class: "#{@champ.blank? ? '' : 'small-margin'}"))
     - if show_info_text?
       .fr-info-text.fr-mb-4w
-        - lien = link_to( " N° #{@champ.selected} ",dossier_url(@champ.selected), target: '_blank', rel: 'noopener' )
-        = sanitize(dossier.text_summary(lien),tags: %w(a), attributes: %w(href target rel))
-- else 
+        %span
+          - lien = link_to( "N° #{@champ.selected}",dossier_url(@champ.selected), target: '_blank', rel: 'noopener' )
+          = sanitize(dossier.text_summary(lien),tags: %w(a), attributes: %w(href target rel))
+- else
   - if render_as_radios?
-    .fr-fieldset__content
+    %fieldset.fr-fieldset.fr-mt-2w
       - dossier_options_for(@champ).each do |item|
         - if item[:value].start_with?('separator_')|| item[:value].start_with?('no_dossier_')
-          %p.fr-text--bold.fr-mt-2w= item[:label]
-        - else 
+          %legend.fr-fieldset__legend--regular.fr-fieldset__legend.fr-text--bold= item[:label]
+        - else
+          .fr-fieldset__element
+            .fr-radio-group
+              = @form.radio_button :value, item[:value], id: "#{@champ.input_id}_#{item[:value]}", translate: 'no'
+              %label.fr-label{ for: "#{@champ.input_id}_#{item[:value]}" }
+                = item[:label]
+      - if !@champ.mandatory?
+        .fr-fieldset__element
           .fr-radio-group
-            = @form.radio_button :value, item[:value], id: "#{@champ.input_id}_#{item[:value]}", translate: 'no'
-            %label.fr-label{ for: "#{@champ.input_id}_#{item[:value]}" }
-              = item[:label]
+            = @form.radio_button :value, '', checked: @champ.value.blank?, id: "#{@champ.input_id}_blank"
+            %label.fr-label{ for: "#{@champ.input_id}_blank" }
+              Non renseigné
       - if show_info_text?
         .fr-info-text.fr-mb-4w
-          - lien = link_to( " N° #{@champ.selected} ",dossier_url(@champ.selected), target: '_blank', rel: 'noopener' )
-          = sanitize(dossier.text_summary(lien),tags: %w(a), attributes: %w(href target rel))
+          %span
+            - lien = link_to( "N° #{@champ.selected}",dossier_url(@champ.selected), target: '_blank', rel: 'noopener' )
+            = sanitize(dossier.text_summary(lien),tags: %w(a), attributes: %w(href target rel))
   - elsif render_as_combobox?
-    %react-fragment.flex-1
-      = render ReactComponent.new "ComboBox/SingleComboBox", **react_props 
+    %react-fragment.flex-1.fr-mt-2w
+      = render ReactComponent.new "ComboBox/SingleComboBox", **react_props
       - if show_info_text?
         .fr-info-text.fr-mb-4w
-          - lien = link_to( " N° #{@champ.selected} ",dossier_url(@champ.selected), target: '_blank', rel: 'noopener' )
-          = sanitize(dossier.text_summary(lien),tags: %w(a), attributes: %w(href target rel))
+          %span
+            - lien = link_to( "N° #{@champ.selected}",dossier_url(@champ.selected), target: '_blank', rel: 'noopener external', class: 'fr-link')
+            = sanitize(dossier.text_summary(lien),tags: %w(a), attributes: %w(href target rel))
   - elsif render_no_dossier?
     - type_champ = @champ.type_de_champ
     - type_champ.procedures.each do |procedure|
       %p Vous n'avez déposé aucun dossier sur la démarche #{procedure.libelle}.
-  - else  
+  - else
     - select_options = dossier_options_for(@champ).map do |item|
       - if item[:value].start_with?('separator_') || item[:value].start_with?('no_dossier_')
         - [item[:label], item[:value], { disabled: true }]
       - else
-        - [item[:label], item[:value]]  
+        - [item[:label], item[:value]]
 
     = @form.select :value,
       select_options,
@@ -48,7 +58,7 @@
         translate: 'no' }
 
     - if show_info_text?
-      .fr-info-text.fr-mb-4w 
+      .fr-info-text.fr-mb-4w
         - lien = link_to( " N° #{@champ.selected} ",dossier_url(@champ.selected), target: '_blank', rel: 'noopener' )
         = sanitize(dossier.text_summary(lien),tags: %w(a), attributes: %w(href target rel))
 

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
@@ -25,15 +25,15 @@
             %label.fr-label{ for: "#{@champ.input_id}_blank" }
               Non renseigné
       - if show_info_text?
-        .fr-info-text.fr-mb-4w
+        .fr-info-text.fr-mb-4w.fr-ml-1w{:style => 'display: inline;'}
           %span
             - lien = link_to( "N° #{@champ.selected}",dossier_url(@champ.selected), target: '_blank', rel: 'noopener' )
             = sanitize(dossier.text_summary(lien),tags: %w(a), attributes: %w(href target rel))
   - elsif render_as_combobox?
-    %react-fragment.flex-1.fr-mt-2w
+    %react-fragment.flex-1.fr-mt-1w
       = render ReactComponent.new "ComboBox/SingleComboBox", **react_props
       - if show_info_text?
-        .fr-info-text.fr-mb-4w
+        .fr-info-text.fr-mb-4w{:style => 'display: inline;'}
           %span
             - lien = link_to( "N° #{@champ.selected}",dossier_url(@champ.selected), target: '_blank', rel: 'noopener external', class: 'fr-link')
             = sanitize(dossier.text_summary(lien),tags: %w(a), attributes: %w(href target rel))
@@ -58,8 +58,8 @@
         translate: 'no' }
 
     - if show_info_text?
-      .fr-info-text.fr-mb-4w
-        - lien = link_to( " N° #{@champ.selected} ",dossier_url(@champ.selected), target: '_blank', rel: 'noopener' )
+      .fr-info-text.fr-mb-4w{:style => 'display: inline;'}
+        - lien = link_to( "N° #{@champ.selected}",dossier_url(@champ.selected), target: '_blank', rel: 'noopener' )
         = sanitize(dossier.text_summary(lien),tags: %w(a), attributes: %w(href target rel))
 
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -738,9 +738,9 @@ class Dossier < ApplicationRecord
         "Dossier déposé le ",
         depose_at.strftime("%d/%m/%Y"),
         " sur la démarche ",
-        "'#{procedure.libelle}'",
+        "\"#{procedure.libelle}\"",
         " gérée par l'organisme ",
-        "'#{procedure.organisation_name}'"
+        "\"#{procedure.organisation_name}\""
       ]
     end
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -735,7 +735,9 @@ class Dossier < ApplicationRecord
       ]
     else
       parts = [
-        "Dossier déposé le ",
+        "Dossier ",
+        lien,
+        " - déposé le ",
         depose_at.strftime("%d/%m/%Y"),
         " sur la démarche ",
         "\"#{procedure.libelle}\"",


### PR DESCRIPTION
> [!IMPORTANT]
> Ne pas merger pour l'instant, voir avec l'équipe comment on s'organise pour les branches de correction UI UX 

# Contenu fonctionnel

L'UI côté usager pour le lien vers un dossier a été amélioré.

# Validation

## Technique

- `app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml` : modification de la structure pour les radio buttons pour que ce soit justifié à gauche. Ajout d'un attribut style au feedback d'info pour que le n° ne soit pas collé. Ajout d'un radio button pour l'option "Non renseigné"
- `app/models/dossier.rb`: ajout du lien et des guillemets pour le texte qui s'affiche dans le feedback d'info

## Fonctionnel

- ETQ administrateur, créer deux démarches : une avec des champs quelconques (Démarche 1) et une avec un champ non obligatoire Lien vers un dossier (Démarche 2) (sélectionner Démarche 1 et Démarche 2 dans l'option Limiter à certaines démarches).
- ETQ usager, déposer un dossier (n°1) sur Démarche 1
- ETQ usager, créer un dossier (n°2) sur Démarche 2
- [ ] Le champ étant non obligatoire, une option "Non renseigné" apparaît
- ETQ administrateur, mettre le champ Lien vers un dossier en obligatoire
- ETQ usager, retourner sur le dossier
- [ ] L'option "Non renseigné" n'apparaît plus
- [ ] Il y a un espacement vertical entre la description du champ et le champ.
- [ ] Tous les éléments sont justifiés à gauche (libellé du champ / description du champ / champ / feedback d’info sur le dossier en bleu)
- ETQ usager, sélectionner un dossier pour faire apparaître le feedback d'info en bleu
- [ ] Il y a un espace entre "Dossier" et "N°", et entre "N°" et " - déposé"
- [ ] L'intitulé de la démarche et le nom du service sont mis entre vrais guillemets (")
- ETQ usager, déposer en tout 20 dossiers sur les démarches
- ETQ usager, créer un nouveau dossier sur la Démarche 2. On a maintenant une combobox pour le Lien vers un dossier
- [ ] Il y a un espacement vertical entre le champ et la description du champ
- [ ] Lors de la recherche, les éléments non sélectionnables (le nom des démarches) n'apparaissent pas mais sont toujours bien présents lorsque le champ de saisi est vide
 